### PR TITLE
Send JSON data instead of array for /analyze endpoint

### DIFF
--- a/server/gui.py
+++ b/server/gui.py
@@ -93,8 +93,10 @@ def compute_accuracy(data):
     typed_text = data.get("typedText", [""])[0]
     start_time = float(data["startTime"][0])
     end_time = float(data["endTime"][0])
-    return [typing_test.wpm(typed_text, end_time - start_time),
-            typing_test.accuracy(typed_text, prompted_text)]
+    return {
+        "wpm": typing_test.wpm(typed_text, end_time - start_time),
+        "accuracy": typing_test.accuracy(typed_text, prompted_text),
+    }
 
 
 def similar(w, v, n):

--- a/src/App.js
+++ b/src/App.js
@@ -123,8 +123,8 @@ class App extends Component {
             endTime: this.getCurrTime(),
         }).done((data) => {
             this.setState({
-                wpm: data[0].toFixed(1),
-                accuracy: data[1].toFixed(1),
+                wpm: data.wpm.toFixed(1),
+                accuracy: data.accuracy.toFixed(1),
                 currTime: this.getCurrTime(),
             });
         });


### PR DESCRIPTION
I don’t think there’s really a reason we should be sending back the `compute_accuracy` data as an array rather than in JSON. The response size barely increases, and it makes more sense for the returned data to be in JSON.