### PR TITLE
Avoid deleting extra character after popping previous word when backspacing

### DIFF
--- a/src/Input.js
+++ b/src/Input.js
@@ -69,6 +69,7 @@ class InputField extends Component {
         }
         this.setText(`${this.props.popPrevWord()} `, false);
         e.preventDefault();
+        this.handleInput(e);
     };
 
     handleInput = (e) => {

--- a/src/Input.js
+++ b/src/Input.js
@@ -68,6 +68,7 @@ class InputField extends Component {
             return;
         }
         this.setText(`${this.props.popPrevWord()} `, false);
+        e.preventDefault();
     };
 
     handleInput = (e) => {

--- a/src/Input.js
+++ b/src/Input.js
@@ -67,7 +67,7 @@ class InputField extends Component {
         if (e.target.innerText !== "") {
             return;
         }
-        this.setText(`${this.props.popPrevWord()} `, false);
+        this.setText(this.props.popPrevWord(), false);
         e.preventDefault();
         this.handleInput(e);
     };


### PR DESCRIPTION
This was just something I found a bit annoying when I was working on the project myself earlier. I just added an extra line to consume the backspace so it doesn’t backspace the last character of the previous word as well as popping it out to be edited.