### PR TITLE
JWT to reduce leaderboard spam

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
 		"bootstrap": "4.3.1",
 		"git": "^0.1.5",
 		"jquery": "^3.4.1",
+		"openssl": "^1.1.0",
 		"popper.js": "^1.15.0",
 		"react": "^16.8.6",
 		"react-bootstrap": "^1.0.0-beta.11",

--- a/server/flask_app.py
+++ b/server/flask_app.py
@@ -37,17 +37,15 @@ else:
 with engine.connect() as conn:
     statement = text(
         """CREATE TABLE IF NOT EXISTS leaderboard (
-    username varchar(128),
-    wpm integer,
-    PRIMARY KEY (`username`)
+    username varchar(32),
+    wpm integer
 );"""
     )
     conn.execute(statement)
     statement = text(
         """CREATE TABLE IF NOT EXISTS memeboard (
-    username varchar(128),
-    wpm integer,
-    PRIMARY KEY (`username`)
+    username varchar(1024),
+    wpm integer
 );"""
     )
     conn.execute(statement)
@@ -327,13 +325,15 @@ def record_name():
     wpm = float(request.form.get("wpm"))
     wpm_token = request.form.get("wpmToken").encode("utf-8")
 
-    if verify_wpm_token(wpm_token, wpm) and len(username) <= 30:
+    if verify_wpm_token(wpm_token, wpm) and len(username) <= 32:
         with engine.connect() as conn:
             conn.execute("INSERT INTO leaderboard (username, wpm) VALUES (%s, %s)", [username, wpm])
     else:
-        return jsonify({
-            "response": "Invalid username, WPM, or WPM token",
-        }), 400
+        return jsonify(
+            {
+                "response": "Invalid username, WPM, or WPM token",
+            }
+        ), 400
     return ""
 
 
@@ -342,8 +342,14 @@ def record_meme():
     username = request.form.get("username")
     wpm = float(request.form.get("wpm"))
 
-    with engine.connect() as conn:
-        conn.execute("INSERT INTO memeboard (username, wpm) VALUES (%s, %s)", [username, wpm])
+    if len(username) <= 1024:
+        with engine.connect() as conn:
+            conn.execute("INSERT INTO memeboard (username, wpm) VALUES (%s, %s)", [username, wpm])
+    else:
+        return jsonify({
+            "response": "Make it shorter!",
+            }
+        ), 400
     return ""
 
 

--- a/server/flask_app.py
+++ b/server/flask_app.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from hashlib import sha256
 from random import randrange
+from secrets import token_bytes
 from urllib.parse import parse_qs
 
 import jwt
@@ -28,7 +29,7 @@ WPM_TOKEN_VALIDITY = 3600
 TIMESTAMP_THRESHOLD = 60
 
 
-token_key = "secret key"
+token_key = token_bytes(32)
 
 
 if __name__ == "__main__":

--- a/server/flask_app.py
+++ b/server/flask_app.py
@@ -346,8 +346,9 @@ def record_meme():
         with engine.connect() as conn:
             conn.execute("INSERT INTO memeboard (username, wpm) VALUES (%s, %s)", [username, wpm])
     else:
-        return jsonify({
-            "response": "Make it shorter!",
+        return jsonify(
+            {
+                "response": "Make it shorter!",
             }
         ), 400
     return ""

--- a/server/flask_app.py
+++ b/server/flask_app.py
@@ -4,14 +4,13 @@ import time
 from collections import defaultdict
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
+from hashlib import sha256
 from random import randrange
 from urllib.parse import parse_qs
 
 import jwt
 from flask import Flask, jsonify, request, send_from_directory
 from sqlalchemy import create_engine, text
-from cryptography.hazmat.backends import default_backend
-from cryptography.hazmat.primitives import hashes
 
 import gui
 import typing_test
@@ -93,9 +92,7 @@ passthrough("/fastest_words")(lambda x: gui.fastest_words(x, lambda targets: [St
 
 
 def hash_message(message):
-    sha256 = hashes.Hash(hashes.SHA256(), backend=default_backend())
-    sha256.update(message)
-    return sha256.finalize()
+    return sha256(message).digest()
 
 
 def generate_p_token(paragraph):

--- a/server/flask_app.py
+++ b/server/flask_app.py
@@ -116,7 +116,10 @@ def generate_s_token(paragraph):
 
 
 def generate_wpm_token(wpm):
-    return str(wpm)
+    return jwt.encode({
+        "wpm": wpm,
+        "exp": round(time.time()) + WPM_TOKEN_VALIDITY,
+    }, token_key).decode("utf-8")
 
 
 def verify_token(token, used_tokens, validity):
@@ -164,10 +167,11 @@ def verify_start_token(token, paragraph, start_time, end_time):
 
 
 def verify_wpm_token(token, wpm):
-    contents = float(token) # TODO Open JWT
     if not verify_token(token, wpm_tokens_used, WPM_TOKEN_VALIDITY):
         return False
-    if round(contents, 1) != round(wpm, 1):
+    claims = jwt.decode(token, verify=False)
+    claimed_wpm = claims["wpm"]
+    if round(claimed_wpm, 1) != round(wpm, 1):
         return False
     mark_token_used(token, wpm_tokens_used, WPM_TOKEN_VALIDITY)
     return True

--- a/server/flask_app.py
+++ b/server/flask_app.py
@@ -326,7 +326,7 @@ def record_name():
             {
                 "response": "Username too long",
             }
-        )
+        ), 400
     with engine.connect() as conn:
         conn.execute("INSERT INTO leaderboard (username, wpm) VALUES (%s, %s)", [username, wpm])
     return ""

--- a/server/flask_app.py
+++ b/server/flask_app.py
@@ -104,14 +104,9 @@ def generate_p_token(paragraph):
 
 @app.route("/request_paragraph", methods=["POST"])
 def request_paragraph():
-    paragraph = gui.request_paragraph(parse_qs(request.get_data().decode("ascii")))
-    p_token = generate_p_token(paragraph)
-    return jsonify(
-        {
-            "paragraph": paragraph,
-            "pToken": p_token,
-        }
-    )
+    response = gui.request_paragraph(parse_qs(request.get_data().decode("ascii")))
+    response["pToken"] = generate_p_token(response["paragraph"])
+    return jsonify(response)
 
 
 def verify_token(token, fernet, used_tokens, validity):

--- a/server/gui.py
+++ b/server/gui.py
@@ -93,8 +93,10 @@ def compute_accuracy(data):
     typed_text = data.get("typedText", [""])[0]
     start_time = float(data["startTime"][0])
     end_time = float(data["endTime"][0])
-    return [typing_test.wpm(typed_text, end_time - start_time),
-            typing_test.accuracy(typed_text, prompted_text)]
+    return {
+        "wpm": typing_test.wpm(typed_text, end_time - start_time),
+        "accuracy": typing_test.accuracy(typed_text, prompted_text),
+    }
 
 
 def similar(w, v, n):

--- a/server/gui.py
+++ b/server/gui.py
@@ -83,7 +83,9 @@ def request_paragraph(data):
     """Return a random paragraph."""
     paragraphs = typing_test.lines_from_file(PARAGRAPH_PATH)
     paragraph_index = randrange(len(paragraphs))
-    return typing_test.choose(paragraphs, lambda x: True, paragraph_index)
+    return {
+        "paragraph": typing_test.choose(paragraphs, lambda x: True, paragraph_index),
+    }
 
 
 @route("/analyze")

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,5 +1,6 @@
 Cryptography
 Flask
 gunicorn
+pyjwt
 SQLAlchemy
 mysqlclient

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,5 +1,5 @@
+Cryptography
 Flask
 gunicorn
 SQLAlchemy
 mysqlclient
-Cryptography

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -2,3 +2,4 @@ Flask
 gunicorn
 SQLAlchemy
 mysqlclient
+Cryptography

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,4 +1,3 @@
-Cryptography
 Flask
 gunicorn
 pyjwt

--- a/src/App.js
+++ b/src/App.js
@@ -89,6 +89,8 @@ class App extends Component {
         $.post("/request_paragraph").done((data) => {
             this.setState({
                 pToken: data.pToken,
+                sToken: "",
+                wpmToken: "",
             });
             if (this.state.pigLatin) {
                 $.post("/translate_to_pig_latin", {

--- a/src/App.js
+++ b/src/App.js
@@ -43,6 +43,9 @@ class App extends Component {
             fastestWords: "",
             showUsernameEntry: false,
             memes: false,
+            pToken: "",
+            sToken: "",
+            wpmToken: "",
         };
         this.timer = null;
         this.multiplayerTimer = null;
@@ -84,9 +87,12 @@ class App extends Component {
         });
 
         $.post("/request_paragraph").done((data) => {
+            this.setState({
+                pToken: data.pToken,
+            });
             if (this.state.pigLatin) {
                 $.post("/translate_to_pig_latin", {
-                    text: data,
+                    text: data.paragraph,
                 }, (translated) => {
                     this.setState({
                         promptedWords: translated.split(" "),
@@ -94,7 +100,7 @@ class App extends Component {
                 });
             } else {
                 this.setState({
-                    promptedWords: data.split(" "),
+                    promptedWords: data.paragraph.split(" "),
                 });
             }
         });
@@ -121,12 +127,25 @@ class App extends Component {
             typedText,
             startTime: this.state.startTime,
             endTime: this.getCurrTime(),
+            pToken: this.state.pToken,
+            sToken: this.state.sToken,
         }).done((data) => {
             this.setState({
                 wpm: data.wpm.toFixed(1),
                 accuracy: data.accuracy.toFixed(1),
                 currTime: this.getCurrTime(),
             });
+            if (data.hasOwnProperty("sToken")) {
+                this.setState({
+                    pToken: "",
+                    sToken: data.sToken
+                });
+            } else if (data.hasOwnProperty("wpmToken")) {
+                this.setState({
+                    sToken: "",
+                    wpmToken: data.wpmToken,
+                });
+            }
         });
     };
 
@@ -287,9 +306,10 @@ class App extends Component {
         $.post("/record_wpm", {
             username,
             wpm: this.state.wpm,
-            confirm: "If you want to mess around, send requests"
-                + " to /record_meme! Leave this endpoint for legit submissions please. Don't be a"
-                + " jerk and ruin this for everyone, thanks!",
+            wpmToken: this.state.wpmToken,
+        });
+        this.setState({
+            wpmToken: "",
         });
         this.hideUsernameEntry();
     };

--- a/src/App.js
+++ b/src/App.js
@@ -286,6 +286,7 @@ class App extends Component {
                     progress: new Array(data.players.length).fill([0, 0]),
                     pigLatin: false,
                     autoCorrect: false,
+                    pToken: data.pToken,
                 });
                 clearInterval(this.multiplayerTimer);
                 this.multiplayerTimer = setInterval(this.requestProgress, 500);

--- a/src/App.js
+++ b/src/App.js
@@ -123,8 +123,8 @@ class App extends Component {
             endTime: this.getCurrTime(),
         }).done((data) => {
             this.setState({
-                wpm: data[0].toFixed(1),
-                accuracy: data[1].toFixed(1),
+                wpm: data.wpm.toFixed(1),
+                accuracy: data.accuracy.toFixed(1),
                 currTime: this.getCurrTime(),
             });
         });

--- a/src/NamePrompt.js
+++ b/src/NamePrompt.js
@@ -30,6 +30,7 @@ export default function NamePrompt({ show, onHide, onSubmit }) {
                             id="exampleInputEmail1"
                             aria-describedby="emailHelp"
                             placeholder="Enter username"
+                            maxlength="32"
                         />
                         <small id="emailHelp" className="form-text text-muted">
                     Please don't name yourself anything inappropriate!

--- a/yarn.lock
+++ b/yarn.lock
@@ -1843,6 +1843,13 @@ async@^1.5.2:
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
   integrity sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=
 
+async@^2.0.0:
+  version "2.6.3"
+  resolved "https://registry.yarnpkg.com/async/-/async-2.6.3.tgz#d72625e2344a3656e3a3ad4fa749fa83299d82ff"
+  integrity sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==
+  dependencies:
+    lodash "^4.17.14"
+
 asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
@@ -6106,6 +6113,11 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
 
+lodash@^4.17.14:
+  version "4.17.15"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
+  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
+
 loglevel@^1.4.1:
   version "1.6.3"
   resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.6.3.tgz#77f2eb64be55a404c9fd04ad16d57c1d6d6b1280"
@@ -6400,6 +6412,16 @@ mkdirp@0.5.1, mkdirp@0.5.x, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@
   dependencies:
     minimist "0.0.8"
 
+mout@^0.11.1:
+  version "0.11.1"
+  resolved "https://registry.yarnpkg.com/mout/-/mout-0.11.1.tgz#ba3611df5f0e5b1ffbfd01166b8f02d1f5fa2b99"
+  integrity sha1-ujYR318OWx/7/QEWa48C0fX6K5k=
+
+mout@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/mout/-/mout-1.1.0.tgz#0b29d41e6a80fa9e2d4a5be9d602e1d9d02177f6"
+  integrity sha512-XsP0vf4As6BfqglxZqbqQ8SR6KQot2AgxvR0gG+WtUkf90vUXchMOZQtPf/Hml1rEffJupqL/tIrU6EYhsUQjw==
+
 move-concurrently@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/move-concurrently/-/move-concurrently-1.0.1.tgz#be2c005fda32e0b29af1f05d7c4b33214c701f92"
@@ -6681,6 +6703,14 @@ nwsapi@^2.0.7, nwsapi@^2.1.3:
   resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.1.4.tgz#e006a878db23636f8e8a67d33ca0e4edf61a842f"
   integrity sha512-iGfd9Y6SFdTNldEy2L0GUhcarIutFmk+MPWIn9dmj8NMIup03G08uUF2KGbbmv/Ux4RT0VZJoP/sVbWA6d/VIw==
 
+nyks@^2.9.0:
+  version "2.31.3"
+  resolved "https://registry.yarnpkg.com/nyks/-/nyks-2.31.3.tgz#3dafdbbbeb765519c40b23747e9198c39a1036ba"
+  integrity sha1-Pa/bu+t2VRnECyN0fpGYw5oQNro=
+  dependencies:
+    async "^2.0.0"
+    mout "^1.0.0"
+
 oauth-sign@~0.9.0:
   version "0.9.0"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
@@ -6802,6 +6832,14 @@ onetime@^2.0.0:
   integrity sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=
   dependencies:
     mimic-fn "^1.0.0"
+
+openssl@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/openssl/-/openssl-1.1.0.tgz#72f925577ed0c99531306f84d1153ca10bd3aefd"
+  integrity sha1-cvklV37QyZUxMG+E0RU8oQvTrv0=
+  dependencies:
+    mout "^0.11.1"
+    nyks "^2.9.0"
 
 opn@5.4.0:
   version "5.4.0"


### PR DESCRIPTION
*I’m just going to copy most of this from PR #2 since I just branched off of that branch. I basically took all the tokens and turned them into JWT so that there is some standardization to it. They also use HMAC and aren’t encrypted anymore, but that shouldn’t be an issue. Please see that PR for further info on verification of tokens and conditions for issuing following tokens. The notation has changed, but the principles are the same.*

This PR essentially adds tokens to each step of the typing test process so that students aren’t just able to spam the `POST /record_wpm` endpoint and get themselves on the leaderboard. These tokens are implemented in JWT under the HS256 scheme, and their claims are as follows:

Three tokens are implemented:
- `p_token`: A token verifying that the paragraph claimed by the client was actually sent by the server
  - `hash`: A SHA-256 hash of the paragraph to verify the paragraph was actually sent by the 
server
  - `exp`: The expiration of the token
- `s_token`: A token verifying the true start time (when the first `/analyze` request is made) and tying that time to a particular paragraph
  - `hash` A SHA-256 hash of the paragraph to tie the paragraph to the start time
  - `iat`: The time the token was issued (the time the user started typing the paragraph)
  - `exp`: The expiration of the token
- `wpm_token`: A token verifying that the client’s claimed WPM was actually validly computed by the server
  - `wpm`: The user’s claimed computed WPM, verified by the server
  - `exp`: The expiration of the token

Note that because all used tokens are stored for their period of freshness, they also essentially act as nonces, preventing trivial replay attacks on the /analyze or /record_wpm endpoints. The encryption keys are relatively short-term, always stored in memory and regenerating whenever the program is restarted, so there shouldn’t be much of a problem in terms of post-compromise security.

Because the action of typing is ultimately performed entirely on the client computer, there is no foolproof way of guaranteeing that false results do not make it onto the leaderboard. However, this pull request aims simply to raise the barrier enough to deter the casual CS 61A student from making false posts to the leaderboard in a mostly cryptographically ensured way while remaining completely transparent to the end-user.

*P.S.: I am in no way an expert in any of this and also am in no way an expert in Python, so by all means, do critique/edit my code in case something doesn’t work. Thanks!*